### PR TITLE
main/readme: pinned this version to gcp 2.X.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ EXAMPLE
 ```hcl
 module "dcos-forwarding-rule" {
   source  = "terraform-dcos/compute-forwarding-rule/gcp"
-  version = "~> 0.1.0"
+  version = "~> 0.2.0"
 
   cluster_name = "production"
 

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@
  *```hcl
  * module "dcos-forwarding-rule" {
  *   source  = "terraform-dcos/compute-forwarding-rule/gcp"
- *   version = "~> 0.1.0"
+ *   version = "~> 0.2.0"
  *
  *   cluster_name = "production"
  *
@@ -25,7 +25,9 @@
  *```
  */
 
-provider "google" {}
+provider "google" {
+  version = "~> 2.0"
+}
 
 locals {
   forwarding_rule_name = "${format(var.name_format,var.cluster_name)}"


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-48802

As GCP update the latest version of the provider, we now require to update the templates so that it can select the proper version associated with the change.