### PR TITLE
main: pinning gcp 1.X version to 0.1.X

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,9 @@
  *```
  */
 
-provider "google" {}
+provider "google" {
+  version = "~> 1.0"
+}
 
 locals {
   forwarding_rule_name = "${format(var.name_format,var.cluster_name)}"


### PR DESCRIPTION
The terraform provider google was updated to 2.x with this update the labels where moved to its google-beta provider. As we rely on this labels we either have to stick with an old version or have to use the google-beta provider.

This change will force the google provider to use 1.X version for the 0.1.X of this module.

https://jira.mesosphere.com/browse/DCOS-48802